### PR TITLE
fix(sec): upgrade commons-codec:commons-codec to 1.13

### DIFF
--- a/blogserver/pom.xml
+++ b/blogserver/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
-			<version>1.11</version>
+			<version>1.13</version>
 		</dependency>
 		<dependency>
 			<groupId>mysql</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in commons-codec:commons-codec 1.11
- [MPS-2022-11853](https://www.oscs1024.com/hd/MPS-2022-11853)


### What did I do？
Upgrade commons-codec:commons-codec from 1.11 to 1.13 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS